### PR TITLE
fix: prefill quick-start name from mark param instead of discarding invalid input

### DIFF
--- a/src/client/pages/doc.tsx
+++ b/src/client/pages/doc.tsx
@@ -25,6 +25,7 @@ import {
   DEFAULT_COLLECTION_SETTINGS,
   type CollectionSettings,
 } from "@/shared/types";
+import { MARK_MIN_LENGTH, MARK_MAX_LENGTH } from "@/shared/constants";
 import {
   downloadTokenBackup,
   isTokenBackupAcknowledged,
@@ -38,7 +39,8 @@ import { CollectionSettingsFields } from "@/client/components/collection-setting
 
 type StepId = "name" | "token" | "settings" | "install";
 
-const MARK_PATTERN = /^[a-zA-Z0-9_-]{4,64}$/;
+const sanitizeMark = (value: string) =>
+  value.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, MARK_MAX_LENGTH);
 
 export function DocPage() {
   const t = useTranslations("DocPage");
@@ -62,9 +64,11 @@ export function DocPage() {
   }, [baseUrl, mark, writeToken]);
 
   useEffect(() => {
-    // Prefill from home page's "create your collection" input when present
-    const requested = searchParams.get("mark") ?? "";
-    const m = MARK_PATTERN.test(requested) ? requested : generateRandomMark();
+    // Prefill from home page's "create your collection" input when present.
+    // Keep the user's (sanitized) input even if it's too short — step 1
+    // validation will surface the error instead of silently replacing it.
+    const requested = sanitizeMark(searchParams.get("mark") ?? "");
+    const m = requested || generateRandomMark();
     const tok = generateWriteToken();
     setMark(m);
     setWriteToken(tok);
@@ -121,7 +125,7 @@ export function DocPage() {
 
   const completeStep = async (step: StepId) => {
     if (step === "name") {
-      if (mark.trim().length < 4) {
+      if (mark.trim().length < MARK_MIN_LENGTH) {
         toast.error(t("setup.name.tooShort"));
         return;
       }
@@ -197,7 +201,7 @@ export function DocPage() {
           <Input
             value={mark}
             onChange={(e) => {
-              setMark(e.target.value.replace(/[^a-zA-Z0-9_-]/g, ""));
+              setMark(sanitizeMark(e.target.value));
               setClaimed(false);
               setDone({});
             }}


### PR DESCRIPTION
## What changed

`/doc?mark=<name>` validated the URL param against a strict `/^[a-zA-Z0-9_-]{4,64}$/` pattern and, on any mismatch, silently replaced the user's requested name with a random one. Since the home page passes the typed name through without validation, any name under 4 characters (e.g. `?mark=ddd`) or containing other characters never showed up in the quick-start name field.

The doc page now sanitizes the param (strips disallowed characters, caps at `MARK_MAX_LENGTH`) and prefills the field with whatever remains, falling back to a random name only when nothing is left. If the name is still too short, the existing step-1 validation shows the "at least 4 characters" error on continue, so users see and can correct their own input instead of being handed a random name.

Also:
- Replaced the hardcoded `4` in the step-1 length check with `MARK_MIN_LENGTH`
- Reused the same sanitizer in the name input's `onChange`

## Notes for reviewers

- The 4-character minimum itself is unchanged — it's enforced by `MARK_MIN_LENGTH` and the server schema, so short names like `ddd` still can't be claimed; they're just no longer silently swapped out.
- Verified locally: `?mark=ddd` prefills `ddd` and shows the too-short toast on continue; `?mark=my-bookmarks` prefills normally. `tsc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)